### PR TITLE
Add missing artist relations

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Some models are hardcoded, others are dynamically generated based on existing ta
 The *init* method should be called after establishing a database connection since the library needs to read all the database tables.
 If you are inside a rails project you could put the code above in **config/initializers/active_musicbrainz.rb**.
 
+If you want to establish a different database connection for the ActiveMusicbrainz tables you can call the establish_connection method on ActiveMusicbrainz::Module::Base instead of ActiveRecord::Base:
+
+    ActiveMusicbrainz::Model::Base.establish_connection(YAML.load_file('path/to/config.yml'))
+
 Now under the ActiveMusicbrainz::Model module, you have one model for each MusicBrainz table.
 Here some examples:
 

--- a/active_musicbrainz.gemspec
+++ b/active_musicbrainz.gemspec
@@ -6,8 +6,8 @@ require 'active_musicbrainz/version'
 Gem::Specification.new do |spec|
   spec.name          = "active_musicbrainz"
   spec.version       = ActiveMusicbrainz::VERSION
-  spec.authors       = ["Andrea Franz"]
-  spec.email         = ["andrea@gravityblast.com"]
+  spec.authors       = ["Andrea Franz", "Florian Dejonckheere"]
+  spec.email         = ["andrea@gravityblast.com", "florian@floriandejonckheere.be"]
   spec.description   = %q{ActiveRecord models for the MusicBrainz database.}
   spec.summary       = %q{ActiveRecord models the MusicBrainz database}
   spec.homepage      = "https://github.com/pilu/active_musicbrainz"

--- a/lib/active_musicbrainz/models/base.rb
+++ b/lib/active_musicbrainz/models/base.rb
@@ -1,6 +1,8 @@
 module ActiveMusicbrainz
   module Model
     class Base < ActiveRecord::Base
+      self.abstract_class = true
+
       def self.has_artist_credits
         belongs_to  :artist_credit, foreign_key: :artist_credit
         has_many    :artist_credit_names, through: :artist_credit

--- a/lib/active_musicbrainz/models/base.rb
+++ b/lib/active_musicbrainz/models/base.rb
@@ -1,21 +1,15 @@
 module ActiveMusicbrainz
   module Model
-    module Base
-      def self.included base
-        base.send :extend, ClassMethods
+    class Base < ActiveRecord::Base
+      def self.has_artist_credits
+        belongs_to  :artist_credit, foreign_key: :artist_credit
+        has_many    :artist_credit_names, through: :artist_credit
+        has_many    :artists, through: :artist_credit_names
       end
 
-      module ClassMethods
-        def has_artist_credits
-          belongs_to  :artist_credit, foreign_key: :artist_credit
-          has_many    :artist_credit_names, through: :artist_credit
-          has_many    :artists, through: :artist_credit_names
-        end
-
-        def has_gid
-          define_singleton_method :by_gid do |gid|
-            find_by gid: gid
-          end
+      def self.has_gid
+        define_singleton_method :by_gid do |gid|
+          find_by gid: gid
         end
       end
     end

--- a/lib/active_musicbrainz/models/factory.rb
+++ b/lib/active_musicbrainz/models/factory.rb
@@ -28,10 +28,9 @@ module ActiveMusicbrainz
       end
 
       def build_model_class table_name
-        klass = Class.new ActiveRecord::Base do
+        klass = Class.new Base do
           self.table_name = table_name
           self.inheritance_column = :_sti_type
-          include Base
         end
         Model.const_set camelize_table_name(table_name), klass
       end

--- a/lib/active_musicbrainz/models/model.rb
+++ b/lib/active_musicbrainz/models/model.rb
@@ -20,6 +20,7 @@ module ActiveMusicbrainz
         has_many    :aliases, foreign_key: :artist, class_name: 'ArtistAlias'
         has_many    :l_artist_urls, foreign_key: :entity0
         has_many    :urls, through: :l_artist_urls
+        belongs_to  :gender, foreign_key: :gender, optional: true
         has_gid
       end
 
@@ -44,6 +45,10 @@ module ActiveMusicbrainz
 
       model :artist_alias do
         belongs_to  :artist, foreign_key: :artist
+      end
+
+      model :gender do
+        has_many    :artists, foreign_key: :gender
       end
 
       model :url do

--- a/lib/active_musicbrainz/models/model.rb
+++ b/lib/active_musicbrainz/models/model.rb
@@ -21,6 +21,7 @@ module ActiveMusicbrainz
         has_many    :l_artist_urls, foreign_key: :entity0
         has_many    :urls, through: :l_artist_urls
         belongs_to  :gender, foreign_key: :gender, optional: true
+        belongs_to  :type, foreign_key: :type, class_name: 'ArtistType', optional: true
         has_gid
       end
 
@@ -45,6 +46,10 @@ module ActiveMusicbrainz
 
       model :artist_alias do
         belongs_to  :artist, foreign_key: :artist
+      end
+
+      model :artist_type do
+        has_many    :artists, foreign_key: :type
       end
 
       model :gender do

--- a/lib/active_musicbrainz/models/model.rb
+++ b/lib/active_musicbrainz/models/model.rb
@@ -22,6 +22,7 @@ module ActiveMusicbrainz
         has_many    :urls, through: :l_artist_urls
         belongs_to  :gender, foreign_key: :gender, optional: true
         belongs_to  :type, foreign_key: :type, class_name: 'ArtistType', optional: true
+        belongs_to  :area, foreign_key: :area, optional: true
         has_gid
       end
 
@@ -54,6 +55,15 @@ module ActiveMusicbrainz
 
       model :gender do
         has_many    :artists, foreign_key: :gender
+      end
+
+      model :area do
+        has_many    :artists, foreign_key: :area
+        belongs_to  :type, foreign_key: :type, class_name: 'AreaType', optional: true
+      end
+
+      model :area_type do
+        has_many    :areas, foreign_key: :type
       end
 
       model :url do

--- a/lib/active_musicbrainz/models/model.rb
+++ b/lib/active_musicbrainz/models/model.rb
@@ -2,7 +2,7 @@ module ActiveMusicbrainz
   module Model
     def self.build_models
       Factory.define do
-        ActiveRecord::Base.connection.tables.each do |table_name|
+        Base.connection.tables.each do |table_name|
           model table_name
         end
       end

--- a/lib/active_musicbrainz/version.rb
+++ b/lib/active_musicbrainz/version.rb
@@ -1,3 +1,3 @@
 module ActiveMusicbrainz
-  VERSION = "0.3.1"
+  VERSION = "0.3.2"
 end


### PR DESCRIPTION
Adds the following models and relations:
- `artist#gender`
- `artist#area`
- `artist#type`
- `gender`
- `area`
- `area_type`
- `artist_type`
